### PR TITLE
Fix JSDisconnectedException in DisposeAsync by wrapping JS interop calls in try/catch

### DIFF
--- a/src/BlazorSortable/Internal/SortableBase.cs
+++ b/src/BlazorSortable/Internal/SortableBase.cs
@@ -152,21 +152,20 @@ public abstract class SortableBase : ComponentBase, IAsyncDisposable, IDisposabl
     /// </summary>
     public async ValueTask DisposeAsync()
     {
-        try
+        if (jsModule is not null)
         {
-            if (jsModule is not null)
+            try
             {
                 await jsModule.InvokeVoidAsync("destroySortable", Id);
                 await jsModule.DisposeAsync();
             }
-        }
-        catch (JSDisconnectedException)
-        {
-            // Ignore - Blazor Server Circuit Disconnected
+            catch (JSDisconnectedException)
+            {
+                // Ignore - Blazor Server Circuit Disconnected
+            }
         }
 
         // Dispose selfReference after JavaScript module to prevent ObjectDisposedException
-        // when JS tries to serialize already disposed DotNetObjectReference
         selfReference?.Dispose();
 
         await DisposeAsyncCore();


### PR DESCRIPTION
Exception gets thrown here on Blazor Server when user session times out (default 3min) after hiding browser.